### PR TITLE
fix(dependencies): add vfile-message

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "@types/hast": "^2.0.0",
     "hast-util-from-parse5": "^7.0.0",
     "parse5": "^7.0.0",
-    "vfile": "^5.0.0"
+    "vfile": "^5.0.0",
+    "vfile-message": "^3.0.0"
   },
   "devDependencies": {
     "@types/node": "^18.0.0",


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [X] I read the support docs <!-- https://github.com/syntax-tree/.github/blob/main/support.md -->
*   [X] I read the contributing guide <!-- https://github.com/syntax-tree/.github/blob/main/contributing.md -->
*   [X] I agree to follow the code of conduct <!-- https://github.com/syntax-tree/.github/blob/main/code-of-conduct.md -->
*   [X] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Asyntax-tree&type=Issues -->
*   [X] If applicable, I’ve added docs and tests

### Description of changes

Fixes transitive dependency on `vfile-message` - this was causing issues when using this package with `pnpm` (depending on your [hoist settings](https://pnpm.io/npmrc#dependency-hoisting-settings)).

[vfile-message](https://github.com/vfile/vfile-message) is referenced here: https://github.com/syntax-tree/hast-util-from-html/blob/main/lib/index.js#L64, despite it **not** being included as a dependency here: https://github.com/syntax-tree/hast-util-from-html/blob/main/package.json#L35-L40.

This _is_ working in most cases currently as [hast-util-from-html](https://github.com/syntax-tree/hast-util-from-html) **does** depend on [vfile](https://github.com/vfile/vfile): https://github.com/syntax-tree/hast-util-from-html/blob/main/package.json#L39, and `vfile` depends on `vfile-message`: https://github.com/vfile/vfile/blob/main/package.json#L57, allowing the dependency to be referenced transitively (unless using a package manager like pnpm which supports isolating modules to prevent this issue)


I discovered this when updating [nextra](https://github.com/shuding/nextra) on [turbo.build](https://github.com/vercel/turbo/tree/main/docs):

```
nextra
├─┬ rehype-katex 6.0.2
│ ├─┬ rehype-parse 8.0.4
│ │ ├─┬ hast-util-from-parse5 7.1.0
│ │ │ ├─┬ vfile 5.3.4
│ │ │ │ └── vfile-message 3.1.2
```

<!--do not edit: pr-->
